### PR TITLE
ci: enable Dependabot for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    open-pull-requests-limit: 10
+    versioning-strategy: increase
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Adds `.github/dependabot.yml` to keep dependencies up to date automatically.

**Ecosystems configured:**
- `npm` — weekly, Monday 06:00 UTC, up to 10 open PRs, strategy: `increase`
- `github-actions` — weekly, Monday 06:00 UTC, up to 5 open PRs

No manual steps required after merging — Dependabot activates automatically.