### PR TITLE
feat: add .htaccess, robots.txt and sitemap.xml

### DIFF
--- a/scripts/build-pipeline.mjs
+++ b/scripts/build-pipeline.mjs
@@ -9,7 +9,8 @@
  *  4. Generate responsive WebP variants with sharp
  *  5. Render index.html from template (with JSON-LD)
  *  6. Render one orchestra page per YAML (with JSON-LD)
- *  7. Copy CSS, JS, and LICENSE
+ *  7. Generate sitemap.xml
+ *  8. Copy CSS, JS, LICENSE, robots.txt, and .htaccess
  */
 
 import fs from 'fs';
@@ -396,13 +397,39 @@ async function build() {
     log(`  Written: orchester/${orch.slug}/index.html`);
   }
 
-  // 7. Copy static assets
+  // 7. Generate sitemap.xml
+  log('Generating sitemap.xml...');
+  const today = new Date().toISOString().slice(0, 10);
+  const sitemapUrls = [
+    { loc: `${SITE_URL}/`, changefreq: 'weekly', priority: '1.0', lastmod: today },
+    ...orchestras.map(o => ({
+      loc: `${SITE_URL}/orchester/${o.slug}/`,
+      changefreq: 'monthly',
+      priority: '0.8',
+      lastmod: today,
+    })),
+  ];
+
+  const sitemapXml = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...sitemapUrls.map(u =>
+      `  <url>\n    <loc>${u.loc}</loc>\n    <lastmod>${u.lastmod}</lastmod>\n    <changefreq>${u.changefreq}</changefreq>\n    <priority>${u.priority}</priority>\n  </url>`
+    ),
+    '</urlset>',
+  ].join('\n');
+
+  fs.writeFileSync(path.join(DIST, 'sitemap.xml'), sitemapXml, 'utf8');
+
+  // 8. Copy static assets
   log('Copying static assets...');
   fse.ensureDirSync(path.join(DIST, 'css'));
   fse.ensureDirSync(path.join(DIST, 'js'));
   fse.copySync(SRC_CSS, path.join(DIST, 'css'));
   fse.copySync(SRC_JS, path.join(DIST, 'js'));
   fse.copySync(path.join(ROOT, 'LICENSE'), path.join(DIST, 'LICENSE'));
+  fse.copySync(path.join(ROOT, 'src', 'main', 'robots.txt'), path.join(DIST, 'robots.txt'));
+  fse.copySync(path.join(ROOT, 'src', 'main', '.htaccess'), path.join(DIST, '.htaccess'));
 
   log('Build complete ✓');
   log(`Output: ${DIST}`);

--- a/src/main/.htaccess
+++ b/src/main/.htaccess
@@ -1,0 +1,87 @@
+# musik-in-schaumburg.de – Apache configuration
+
+# ── Encoding ──────────────────────────────────────────────────────────────────
+AddDefaultCharset UTF-8
+
+# ── HTTPS redirect ────────────────────────────────────────────────────────────
+RewriteEngine On
+
+RewriteCond %{HTTPS} off
+RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+
+# ── Canonical host: redirect www → non-www ────────────────────────────────────
+RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
+RewriteRule ^ https://%1%{REQUEST_URI} [R=301,L]
+
+# ── Pre-compressed Brotli / gzip serving ──────────────────────────────────────
+<IfModule mod_headers.c>
+  # Brotli
+  RewriteCond %{HTTP:Accept-Encoding} br
+  RewriteCond %{REQUEST_FILENAME}.br -f
+  RewriteRule ^ %{REQUEST_URI}.br [L]
+
+  <FilesMatch "\.br$">
+    Header set Content-Encoding br
+    Header append Vary Accept-Encoding
+  </FilesMatch>
+
+  # Gzip
+  RewriteCond %{HTTP:Accept-Encoding} gzip
+  RewriteCond %{REQUEST_FILENAME}.gz -f
+  RewriteRule ^ %{REQUEST_URI}.gz [L]
+
+  <FilesMatch "\.gz$">
+    Header set Content-Encoding gzip
+    Header append Vary Accept-Encoding
+  </FilesMatch>
+</IfModule>
+
+# ── MIME types for pre-compressed files ───────────────────────────────────────
+<FilesMatch "\.css\.(br|gz)$">
+  ForceType text/css
+</FilesMatch>
+<FilesMatch "\.js\.(br|gz)$">
+  ForceType application/javascript
+</FilesMatch>
+<FilesMatch "\.html\.(br|gz)$">
+  ForceType text/html
+</FilesMatch>
+
+# ── Caching ───────────────────────────────────────────────────────────────────
+<IfModule mod_expires.c>
+  ExpiresActive On
+
+  # HTML – short TTL so updates reach users quickly
+  ExpiresByType text/html                  "access plus 1 hour"
+
+  # CSS and JS – fingerprint in filename assumed; long TTL is safe
+  ExpiresByType text/css                   "access plus 1 year"
+  ExpiresByType application/javascript     "access plus 1 year"
+
+  # Images
+  ExpiresByType image/webp                 "access plus 1 year"
+  ExpiresByType image/jpeg                 "access plus 1 year"
+  ExpiresByType image/png                  "access plus 1 year"
+  ExpiresByType image/svg+xml              "access plus 1 year"
+  ExpiresByType image/x-icon              "access plus 1 year"
+
+  # Fonts
+  ExpiresByType font/woff2                 "access plus 1 year"
+  ExpiresByType font/woff                  "access plus 1 year"
+
+  # Sitemap and robots.txt – refresh daily
+  ExpiresByType application/xml            "access plus 1 day"
+  ExpiresByType text/xml                   "access plus 1 day"
+  ExpiresByType text/plain                 "access plus 1 day"
+</IfModule>
+
+# ── Security headers ──────────────────────────────────────────────────────────
+<IfModule mod_headers.c>
+  Header always set X-Content-Type-Options "nosniff"
+  Header always set X-Frame-Options        "SAMEORIGIN"
+  Header always set Referrer-Policy        "strict-origin-when-cross-origin"
+  Header always set Permissions-Policy     "camera=(), microphone=(), geolocation=()"
+</IfModule>
+
+# ── Error documents ───────────────────────────────────────────────────────────
+ErrorDocument 404 /index.html

--- a/src/main/robots.txt
+++ b/src/main/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://musik-in-schaumburg.de/sitemap.xml


### PR DESCRIPTION
## What this adds

### `.htaccess` (`src/main/.htaccess` → `dist/.htaccess`)

| Feature | Detail |
|---|---|
| HTTP → HTTPS | 301 redirect |
| www → non-www | 301 redirect to canonical host |
| Pre-compressed serving | Brotli (`.br`) and gzip (`.gz`) variants detected and served transparently |
| Caching | 1 year for CSS/JS/images/fonts; 1 hour for HTML; 1 day for sitemap + robots.txt |
| Security headers | `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy` |
| Soft 404 | Falls back to `index.html` |

### `robots.txt` (`src/main/robots.txt` → `dist/robots.txt`)
- Allows all crawlers
- References the sitemap

### `sitemap.xml` (generated by build pipeline)
- Homepage: `changefreq: weekly`, `priority: 1.0`
- Each orchestra page: `changefreq: monthly`, `priority: 0.8`
- `lastmod` set to the build date (ISO 8601)
- Regenerated on every `bun run build`

### Build pipeline changes
- Step 7 (new): generates `dist/sitemap.xml`
- Step 8 (was 7): copies static assets — now also includes `robots.txt` and `.htaccess`