### PR TITLE
fix: local asset handling cleanup and bug fixes

### DIFF
--- a/scripts/build-pipeline.mjs
+++ b/scripts/build-pipeline.mjs
@@ -384,6 +384,16 @@ async function build() {
             }
 
             imgReady = true;
+          } else {
+            // generateImageVariants returned null (no WebP variants), but may have written a JPEG fallback
+            const jpegFallback = path.join(orchImgDir, 'photo-800w.jpg');
+            if (fs.existsSync(jpegFallback)) {
+              orch.image = { ...orch.image, fallback: 'images/photo-800w.jpg', hasSrcset: false };
+              imgReady = true;
+            }
+            if (downloaded && fs.existsSync(localImgPath)) {
+              try { fs.unlinkSync(localImgPath); } catch (e) {}
+            }
           }
         } catch (e) {
           console.warn(`[build] WARN: Could not process image for ${orch.slug}: ${e.message}`);
@@ -392,13 +402,6 @@ async function build() {
       }
 
       if (!imgReady) {
-        orch.image = null;
-      }
-    } else {
-      orch.image = null;
-    }
-        fs.unlinkSync(localImgPath);
-      } else {
         orch.image = null;
       }
     } else {
@@ -445,20 +448,21 @@ async function build() {
       if (localLogoPath) {
         try {
           const logoLocal = await generateLogoVariant(localLogoPath, orchImgDir, 'logo');
-          if (!String(localLogoPath).startsWith(orchImgDir)) {
-            // copy original into folder
-            const fallbackName = `logo-original${path.extname(localLogoPath)}`;
-            fse.copySync(localLogoPath, path.join(orchImgDir, fallbackName));
+          if (logoLocal) {
+            if (!String(localLogoPath).startsWith(orchImgDir)) {
+              // copy original into folder as fallback
+              const fallbackName = `logo-original${path.extname(localLogoPath)}`;
+              fse.copySync(localLogoPath, path.join(orchImgDir, fallbackName));
+            }
             orch.logo = { ...orch.logo, local: logoLocal };
+            logoReady = true;
           } else {
-            orch.logo = { ...orch.logo, local: logoLocal };
+            console.warn(`[build] WARN: Logo variant generation returned null for ${orch.slug}.`);
           }
 
           if (downloadedLogo && fs.existsSync(localLogoPath)) {
             try { fs.unlinkSync(localLogoPath); } catch (e) {}
           }
-
-          logoReady = true;
         } catch (e) {
           console.warn(`[build] WARN: Could not process logo for ${orch.slug}: ${e.message}`);
           if (downloadedLogo && fs.existsSync(localLogoPath)) try { fs.unlinkSync(localLogoPath); } catch (e) {}


### PR DESCRIPTION
## What

Fixes a critical syntax error and two logic bugs introduced in the previous commit (*feat: prefer local image/logo*).

## Bugs Fixed

### 🔴 Critical — SyntaxError: dangling else-blocks
Lines 400–406 were leftover fragments from the old image-processing code, still present after the rewrite. They caused `SyntaxError: Unexpected token 'else'` at runtime, making the build completely broken.

### 🟡 Medium — Null variants not falling back to JPEG
When `generateImageVariants` returned `null` (no WebP variants produced), the image was silently discarded. `generateImageVariants` may already have written a `photo-800w.jpg` fallback — this is now used instead of dropping the image entirely.

### 🟡 Medium — logoReady incorrectly set when logo is null
`logoReady = true` was set unconditionally after calling `generateLogoVariant`, even when it returned `null` (sharp failure). This left `orch.logo = { local: null }` instead of `null`, causing templates to render a broken logo path. Fixed by guarding with `if (logoLocal)`.

### 🔵 Minor — Redundant logo copy branches
The `if/else` branches both assigned `orch.logo` identically; deduplicated.

## Verified

- `node --check scripts/build-pipeline.mjs` → ✓ Syntax OK
- `bun run build` → ✓ Build complete, 8 files pre-compressed

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>