### PR TITLE
content: rewrite ensemble descriptions with original text

### DIFF
--- a/ensembles/blasorchester-bueckeburger-jaeger/index.yaml
+++ b/ensembles/blasorchester-bueckeburger-jaeger/index.yaml
@@ -9,9 +9,12 @@ image:
   url: "https://www.bueckeburger-jaeger.de/s/img/emotionheader_3.jpg"
 
 description: >
-  Das Blasorchester „Bückeburger Jäger" ist das Stadtorchester der ehemaligen
-  Fürstenresidenz Bückeburg, welche am Rande des Weserberglandes, ca. 50 km
-  westlich von Hannover, liegt.
+  1949 als Musikkorps des Bückeburger Jägerbataillons gegründet und seit 1975 als eingetragener
+  Verein aktiv, vereint das Blasorchester heute rund 32 Musikerinnen und Musiker von 18 bis 80 Jahren
+  unter der Leitung von José Pascual García Llopis.
+  Das Repertoire reicht von Militärmusik und traditioneller Blasmusik bis zu moderner Konzertliteratur –
+  besondere Bekanntheit genießen die Weihnachtsserenaden im Schlosshof Bückeburg sowie die
+  Benefizkonzerte für die Tschernobylhilfe, bei denen bislang über 500.000 Euro gesammelt wurden.
 
 location: "Jägerkaserne Bückeburg"
 website: "https://www.bueckeburger-jaeger.de/"

--- a/ensembles/blasorchester-krainhagen/index.yaml
+++ b/ensembles/blasorchester-krainhagen/index.yaml
@@ -6,9 +6,12 @@ image:
   url: "https://blasorchester-krainhagen.de/wp-content/uploads/cropped-53360358064_0f74e7fd45_o.jpg"
 
 description: >
-  Vor 70 Jahren als Spielmannszug gestartet – heute ist es das Blasorchester
-  Krainhagen, kurz BOK genannt, das im ganzen Schaumburger Land bekannt und
-  beliebt ist.
+  Aus einem Spielmannszug vor mehr als 70 Jahren hervorgegangen, ist das BOK Blasorchester Krainhagen
+  unter Dirigent Sven Schnee mit über 40 Musikerinnen und Musikern zu einem festen Bestandteil des
+  Schaumburger Kulturlebens geworden.
+  Mit dem selbst entwickelten Format der „Schaumburg Proms"-Konzerte bespielt das Orchester
+  ungewöhnliche Spielstätten – von gotischen Stiftskirchen über historische Rathaussäle bis zu
+  Freilichtbühnen – und schloss zuletzt auch gemeinsame Konzertabende mit dem Schaumburger Jugendchor ein.
 
 location: "Krainhagen"
 website: "https://blasorchester-krainhagen.de/"

--- a/ensembles/brassband-stadthagen/index.yaml
+++ b/ensembles/brassband-stadthagen/index.yaml
@@ -9,10 +9,11 @@ image:
   url: "https://www.brassband-stadthagen.de/wp-content/uploads/photo-gallery/St-Martini-Brass-Band-2022_2.jpg?bwg=1698786710"
 
 description: >
-  Die St. Martini-Brass-Band Stadthagen ist ein Blasorchester in der Tradition
-  britischer Brass Bands. Mit einem vielseitigen Repertoire von klassischer
-  Blasmusik bis hin zu modernen Arrangements begeistert das Ensemble das
-  Publikum bei Konzerten in der Region Schaumburg.
+  Die St. Martini-Brass-Band Stadthagen pflegt die Tradition britischer Brass Bands und tritt in der
+  St.-Martini-Kirche mit einem Programm aus Originalliteratur, Chorälen, Filmmusik und
+  Jazz-Arrangements auf – der Eintritt ist dabei stets frei.
+  Neben dem Hauptensemble fördert die der Kirchengemeinde St. Martini angegliederte Kapelle mit
+  ihrer Jugend-Brass-Band aktiv den musikalischen Nachwuchs in Stadthagen.
 
 location: "Stadthagen"
 website: "https://www.brassband-stadthagen.de/"

--- a/ensembles/sbo-schaumburg/index.yaml
+++ b/ensembles/sbo-schaumburg/index.yaml
@@ -9,10 +9,12 @@ image:
   url: "https://www.sbo-schaumburg.de/das-orchester/sbo-schaumburg-orchesterfoto.jpg"
 
 description: >
-  Das Sinfonische Blasorchester Schaumburg (SBO) ist ein großes Sinfonisches
-  Blasorchester aus dem Landkreis Schaumburg. Das Orchester pflegt ein
-  anspruchsvolles sinfonisches Repertoire und präsentiert dieses in
-  regelmäßigen Konzerten der Öffentlichkeit.
+  Das Sinfonische Blasorchester Schaumburg (SBO) aus Lauenhagen widmet sich unter der Leitung von
+  Stephan Winkelhake einem gehobenen Konzertrepertoire mit Werken von George Gershwin und
+  Klaus-Peter Bruchmann sowie sinfonischen Filmmusikbearbeitungen nach Johan de Meij.
+  Das Ensemble trat regelmäßig in der Aula des Ratsgymnasiums Stadthagen auf und gestaltete
+  gemeinsame Konzertabende mit befreundeten Orchestern der Region, darunter Bläserensembles des
+  Wilhelm-Busch-Gymnasiums.
 
 location: "Lauenhagen"
 website: "https://www.sbo-schaumburg.de/"


### PR DESCRIPTION
All four descriptions were copied verbatim from the respective ensemble homepages. This PR replaces them with independently written two-sentence summaries.

## Changes per ensemble

**Blasorchester Bückeburger Jäger e.B.**
Founded 1949 as a military music corps, registered association since 1975. ~32 musicians ages 18–80, conductor José Pascual García Llopis, annual Christmas serenades at Bückeburg castle courtyard, over €500,000 raised for Tschernobylhilfe Swonez.

**BOK – Blasorchester Krainhagen**
70+ year history from a Spielmannszug, conductor Sven Schnee, 40+ musicians. Known for the self-created "Schaumburg Proms" concert format at unusual venues (Stiftskirche, Rathaussäle, parks) and joint concerts with the Schaumburger Jugendchor.

**Sinfonisches Blasorchester Schaumburg**
Conductor Stephan Winkelhake, based in Lauenhagen. Repertoire: Gershwin, Klaus-Peter Bruchmann, film music arrangements by Johan de Meij. Regular concerts in the Aula des Ratsgymnasiums Stadthagen.

**St. Martini-Brass-Band Stadthagen**
British brass band tradition, affiliated with the St. Martini Kirchengemeinde. Free-admission concerts in St.-Martini-Kirche with original literature, chorals, film music and jazz; also runs a Jugend-Brass-Band.