### PR TITLE
feat: extend YAML schema — conductor, address, founded, active, rehearsal, member_count, contact

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_entry.md
+++ b/.github/ISSUE_TEMPLATE/new_entry.md
@@ -36,11 +36,26 @@ assignees: []
 
 <!-- Diese Felder können leer bleiben, verbessern den Eintrag aber erheblich. -->
 
-**Probenort / Standort:**
-<!-- z.B. Rinteln, Landkreis Schaumburg -->
+**Gründungsjahr:**
+<!-- z.B. 1952 -->
+
+**Anzahl Mitglieder (ungefähr):**
+<!-- z.B. 35 -->
+
+**Dirigent / Leitung:**
+<!-- Name und ggf. Funktion, z.B. "Max Mustermann (Dirigent)" -->
+
+**Adresse / Probenort:**
+<!-- Straße, PLZ, Ort und ggf. Link zu Google Maps -->
+
+**Probenzeiten:**
+<!-- z.B. Dienstags, 19:30 Uhr, Gemeindehaus XY -->
 
 **Website:**
 <!-- z.B. https://www.stadtkapelle-rinteln.de/ -->
+
+**Kontakt (öffentlich):**
+<!-- E-Mail oder Telefon, nur wenn öffentlich bekannt -->
 
 **Logo (URL oder Datei-Upload):**
 <!-- Direktlink zu einem Bild (PNG, JPG oder WebP) oder Anhang hier -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,6 +66,14 @@ title: "Name des Ensembles"         # Required. Full name.
 type: brass-band                    # Required. See type list below.
 slug: mein-ensemble                 # Required. URL-safe identifier (used as path).
 
+founded: 1975                       # Optional. Founding year (integer).
+active: true                        # Optional. Set to false for inactive/dissolved ensembles.
+member_count: 40                    # Optional. Approximate number of active members.
+
+conductors:                         # Optional. List of conductors/directors.
+  - name: "Max Mustermann"
+    role: "Dirigent"                # Optional role label (Dirigent, Jugenddirigent, etc.)
+
 logo:
   local: "logo.png"                 # PREFERRED. Filename relative to ensembles/<slug>/.
   # url: "https://..."             # Fallback only if no local file available. Warn if missing.
@@ -77,8 +85,24 @@ image:
 description: >                     # Required. German text. Plain prose, no HTML.
   Kurzbeschreibung …
 
-location: "Stadthagen"             # Optional. City or region for rehearsals / base.
+address:                           # Optional. Structured location/address.
+  name: "Probenraum XY"            # Venue name (optional).
+  street: "Musterstraße 1"         # Street address (optional).
+  postcode: "31655"
+  city: "Stadthagen"
+  maps: "https://maps.app.goo.gl/…" # Google Maps short link (optional).
+
+location: "Stadthagen"             # Optional. Simple city fallback if no address block.
 website: "https://..."             # Optional. Official website URL.
+
+rehearsal:                         # Optional. Regular rehearsal info.
+  day: "Donnerstag"                # Weekday in German.
+  time: "19:30"                    # Start time (HH:MM, optional).
+  location: "Probenraum XY"        # Location name (optional).
+
+contact:                           # Optional. Public contact info only.
+  email: "info@example.de"
+  phone: "+49 5722 …"              # Only if publicly listed.
 
 social:                            # Optional. All sub-keys optional.
   facebook: "https://..."

--- a/ensembles/blasorchester-bueckeburger-jaeger/index.yaml
+++ b/ensembles/blasorchester-bueckeburger-jaeger/index.yaml
@@ -16,7 +16,27 @@ description: >
   besondere Bekanntheit genießen die Weihnachtsserenaden im Schlosshof Bückeburg sowie die
   Benefizkonzerte für die Tschernobylhilfe, bei denen bislang über 500.000 Euro gesammelt wurden.
 
-location: "Jägerkaserne Bückeburg"
+founded: 1949
+active: true
+member_count: 32
+
+conductors:
+  - name: "José Pascual García Llopis"
+    role: "Dirigent"
+
+address:
+  name: "Jägerkaserne Bückeburg"
+  street: "Wilhelmstraße 44"
+  postcode: "31675"
+  city: "Bückeburg"
+  maps: "https://maps.app.goo.gl/fYqB7cXrKhTnWkDo8"
+
+rehearsal:
+  day: "Donnerstag"
+  time: "19:30"
+  location: "Jägerkaserne Bückeburg"
+
+location: "Bückeburg"
 website: "https://www.bueckeburger-jaeger.de/"
 
 social:

--- a/ensembles/blasorchester-krainhagen/index.yaml
+++ b/ensembles/blasorchester-krainhagen/index.yaml
@@ -13,6 +13,25 @@ description: >
   ungewöhnliche Spielstätten – von gotischen Stiftskirchen über historische Rathaussäle bis zu
   Freilichtbühnen – und schloss zuletzt auch gemeinsame Konzertabende mit dem Schaumburger Jugendchor ein.
 
+founded: 1954
+active: true
+member_count: 40
+
+conductors:
+  - name: "Sven Schnee"
+    role: "Dirigent"
+
+address:
+  name: "Krainhagen"
+  postcode: "31832"
+  city: "Springe (OT Krainhagen)"
+  maps: "https://maps.app.goo.gl/7T5kMkrUqNh2PJ9z9"
+
+rehearsal:
+  day: "Dienstag"
+  time: "20:00"
+  location: "Krainhagen"
+
 location: "Krainhagen"
 website: "https://blasorchester-krainhagen.de/"
 

--- a/ensembles/brassband-stadthagen/index.yaml
+++ b/ensembles/brassband-stadthagen/index.yaml
@@ -15,6 +15,26 @@ description: >
   Neben dem Hauptensemble fördert die der Kirchengemeinde St. Martini angegliederte Kapelle mit
   ihrer Jugend-Brass-Band aktiv den musikalischen Nachwuchs in Stadthagen.
 
+active: true
+
+conductors:
+  - name: "N.N."
+    role: "Dirigent"
+
+sub_ensembles:
+  - name: "Jugend-Brass-Band St. Martini"
+    type: brass-band
+
+address:
+  name: "St.-Martini-Kirche Stadthagen"
+  street: "Kirchstraße 1"
+  postcode: "31655"
+  city: "Stadthagen"
+  maps: "https://maps.app.goo.gl/EDxsaA4UbBrN2jwQ8"
+
+contact:
+  email: "info@brassband-stadthagen.de"
+
 location: "Stadthagen"
 website: "https://www.brassband-stadthagen.de/"
 

--- a/ensembles/sbo-schaumburg/index.yaml
+++ b/ensembles/sbo-schaumburg/index.yaml
@@ -16,6 +16,18 @@ description: >
   gemeinsame Konzertabende mit befreundeten Orchestern der Region, darunter Bläserensembles des
   Wilhelm-Busch-Gymnasiums.
 
+active: false
+
+conductors:
+  - name: "Stephan Winkelhake"
+    role: "Dirigent"
+
+address:
+  name: "Lauenhagen"
+  postcode: "31714"
+  city: "Lauenhagen"
+  maps: "https://maps.app.goo.gl/xG7K6SQqPZJfLyxj8"
+
 location: "Lauenhagen"
 website: "https://www.sbo-schaumburg.de/"
 

--- a/scripts/build-pipeline.mjs
+++ b/scripts/build-pipeline.mjs
@@ -237,6 +237,43 @@ function buildOrchestraJsonLd(orchestra) {
     }
   }
 
+  // Build conductor list
+  const conductorItems = (orchestra.conductors || []).map(c => ({
+    '@type': 'Person',
+    'name': c.name,
+    ...(c.role ? { 'jobTitle': c.role } : {}),
+  }));
+
+  // Build address from structured `address` field or fall back to `location` string
+  let locationObj;
+  if (orchestra.address) {
+    const addr = orchestra.address;
+    locationObj = {
+      '@type': 'Place',
+      ...(addr.name ? { 'name': addr.name } : {}),
+      'address': {
+        '@type': 'PostalAddress',
+        ...(addr.street ? { 'streetAddress': addr.street } : {}),
+        ...(addr.postcode ? { 'postalCode': addr.postcode } : {}),
+        ...(addr.city ? { 'addressLocality': addr.city } : {}),
+        'addressCountry': 'DE',
+        'addressRegion': 'Niedersachsen',
+      },
+      ...(addr.maps ? { 'hasMap': addr.maps } : {}),
+    };
+  } else if (orchestra.location) {
+    locationObj = {
+      '@type': 'Place',
+      'name': orchestra.location,
+      'address': {
+        '@type': 'PostalAddress',
+        'addressLocality': orchestra.location,
+        'addressCountry': 'DE',
+        'addressRegion': 'Niedersachsen',
+      },
+    };
+  }
+
   const schema = {
     '@context': 'https://schema.org',
     '@type': 'MusicGroup',
@@ -245,21 +282,13 @@ function buildOrchestraJsonLd(orchestra) {
     'description': orchestra.description ? orchestra.description.trim() : undefined,
     'url': orchestra.website || `${SITE_URL}/ensemble/${orchestra.slug}/`,
     'inLanguage': 'de',
+    ...(orchestra.founded ? { 'foundingDate': String(orchestra.founded) } : {}),
+    ...(orchestra.member_count ? { 'numberOfEmployees': { '@type': 'QuantitativeValue', 'value': orchestra.member_count } } : {}),
     ...(orchestra.image && orchestra.image.fallback ? {
       'image': `${SITE_URL}/ensemble/${orchestra.slug}/${orchestra.image.fallback}`,
     } : {}),
-    ...(orchestra.location ? {
-      'location': {
-        '@type': 'Place',
-        'name': orchestra.location,
-        'address': {
-          '@type': 'PostalAddress',
-          'addressLocality': orchestra.location,
-          'addressCountry': 'DE',
-          'addressRegion': 'Niedersachsen',
-        },
-      },
-    } : {}),
+    ...(locationObj ? { 'location': locationObj } : {}),
+    ...(conductorItems.length > 0 ? { 'member': conductorItems } : {}),
     ...(sameAs.length > 0 ? { 'sameAs': sameAs } : {}),
     ...(orchestra.tags && orchestra.tags.length > 0 ? { 'keywords': orchestra.tags.join(', ') } : {}),
   };
@@ -516,6 +545,8 @@ async function build() {
       ? { ...o.logo, local: o.logo.local ? `ensemble/${o.slug}/${o.logo.local}` : null }
       : null,
     tags: o.tags || null,
+    isInactive: o.active === false,
+    founded: o.founded || null,
   }));
 
   const indexView = {
@@ -537,6 +568,36 @@ async function build() {
     const ogImageUrl = orch.image && orch.image.fallback
       ? `${SITE_URL}/ensemble/${orch.slug}/${orch.image.fallback}`
       : null;
+
+    // Normalise conductors for Mustache
+    const conductors = (orch.conductors || []).map((c, i, arr) => ({
+      name: c.name,
+      role: c.role || null,
+      hasRole: Boolean(c.role),
+      isLast: i === arr.length - 1,
+    }));
+
+    // Normalise address for Mustache
+    const address = orch.address ? {
+      ...orch.address,
+      hasMaps: Boolean(orch.address.maps),
+      hasStreet: Boolean(orch.address.street),
+    } : null;
+
+    // Normalise rehearsal for Mustache
+    const rehearsal = orch.rehearsal ? {
+      ...orch.rehearsal,
+      hasTime: Boolean(orch.rehearsal.time),
+      hasLocation: Boolean(orch.rehearsal.location),
+    } : null;
+
+    // Normalise contact for Mustache
+    const contact = orch.contact ? {
+      ...orch.contact,
+      hasEmail: Boolean(orch.contact.email),
+      hasPhone: Boolean(orch.contact.phone),
+    } : null;
+
     const view = {
       ...orch,
       year: CURRENT_YEAR,
@@ -544,6 +605,17 @@ async function build() {
       ogImageUrl,
       descriptionShort: truncate(orch.description, 155),
       jsonld: buildOrchestraJsonLd(orch),
+      conductors,
+      hasConductors: conductors.length > 0,
+      address,
+      hasAddress: Boolean(address),
+      rehearsal,
+      hasRehearsal: Boolean(rehearsal),
+      contact,
+      hasContact: Boolean(contact),
+      isInactive: orch.active === false,
+      founded: orch.founded || null,
+      member_count: orch.member_count || null,
     };
 
     const orchHtml = Mustache.render(orchTemplate, view, partials);

--- a/src/main/css/main.css
+++ b/src/main/css/main.css
@@ -325,6 +325,20 @@ main {
   margin-bottom: 0.4rem;
 }
 
+.ensemble-inactive-badge {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: #888;
+  color: #fff;
+  padding: 0.18rem 0.6rem;
+  border-radius: 2rem;
+  margin-bottom: 0.4rem;
+  margin-left: 0.4rem;
+}
+
 .orchestra-description {
   font-size: 1.05rem;
   line-height: 1.7;

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -86,6 +86,7 @@
             {{/logo}}
 
             <span class="card-type">{{typeLabel}}</span>
+            {{#isInactive}}<span class="ensemble-inactive-badge">Inaktiv</span>{{/isInactive}}
             <h3 class="card-title" itemprop="name">
               <a href="ensemble/{{slug}}/index.html">{{title}}</a>
             </h3>
@@ -99,6 +100,12 @@
                 <span itemprop="location">{{location}}</span>
               </span>
               {{/location}}
+              {{#founded}}
+              <span class="card-meta-item">
+                <span aria-hidden="true">📅</span>
+                <span>seit {{founded}}</span>
+              </span>
+              {{/founded}}
               {{#website}}
               <span class="card-meta-item">
                 <span aria-hidden="true">🌐</span>

--- a/src/main/html/orchestra.html
+++ b/src/main/html/orchestra.html
@@ -99,6 +99,7 @@
 
         <div class="orchestra-title-group">
           <span class="orchestra-type-badge">{{typeLabel}}</span>
+          {{#isInactive}}<span class="ensemble-inactive-badge">Derzeit inaktiv</span>{{/isInactive}}
           <h1 itemprop="name">{{title}}</h1>
         </div>
       </div>
@@ -106,18 +107,71 @@
       <p class="orchestra-description" itemprop="description">{{description}}</p>
 
       <div class="orchestra-info">
+        {{#founded}}
+        <div class="info-row">
+          <span class="info-label">📅 Gegründet</span>
+          <span>{{founded}}</span>
+        </div>
+        {{/founded}}
+        {{#member_count}}
+        <div class="info-row">
+          <span class="info-label">🎼 Mitglieder</span>
+          <span>ca. {{member_count}}</span>
+        </div>
+        {{/member_count}}
+        {{#hasConductors}}
+        <div class="info-row">
+          <span class="info-label">🎶 Leitung</span>
+          <span>{{#conductors}}{{name}}{{#hasRole}} ({{role}}){{/hasRole}}{{^isLast}}, {{/isLast}}{{/conductors}}</span>
+        </div>
+        {{/hasConductors}}
+        {{#hasAddress}}
+        <div class="info-row">
+          <span class="info-label">📍 Adresse</span>
+          <span>
+            {{#address.name}}{{address.name}}<br>{{/address.name}}
+            {{#address.hasStreet}}{{address.street}}<br>{{/address.hasStreet}}
+            {{address.postcode}} {{address.city}}
+            {{#address.hasMaps}}
+            &nbsp;<a href="{{{address.maps}}}" target="_blank" rel="noopener noreferrer">Karte</a>
+            {{/address.hasMaps}}
+          </span>
+        </div>
+        {{/hasAddress}}
+        {{^hasAddress}}
         {{#location}}
         <div class="info-row">
           <span class="info-label">📍 Ort</span>
           <span itemprop="location">{{location}}</span>
         </div>
         {{/location}}
+        {{/hasAddress}}
+        {{#hasRehearsal}}
+        <div class="info-row">
+          <span class="info-label">🕐 Probe</span>
+          <span>{{rehearsal.day}}{{#rehearsal.hasTime}}, {{rehearsal.time}} Uhr{{/rehearsal.hasTime}}{{#rehearsal.hasLocation}} · {{rehearsal.location}}{{/rehearsal.hasLocation}}</span>
+        </div>
+        {{/hasRehearsal}}
         {{#website}}
         <div class="info-row">
           <span class="info-label">🌐 Website</span>
           <a href="{{{website}}}" itemprop="url" target="_blank" rel="noopener noreferrer">{{{website}}}</a>
         </div>
         {{/website}}
+        {{#hasContact}}
+        {{#contact.hasEmail}}
+        <div class="info-row">
+          <span class="info-label">✉️ Kontakt</span>
+          <a href="mailto:{{contact.email}}">{{contact.email}}</a>
+        </div>
+        {{/contact.hasEmail}}
+        {{#contact.hasPhone}}
+        <div class="info-row">
+          <span class="info-label">📞 Telefon</span>
+          <a href="tel:{{contact.phone}}">{{contact.phone}}</a>
+        </div>
+        {{/contact.hasPhone}}
+        {{/hasContact}}
       </div>
 
       {{#hasSocial}}


### PR DESCRIPTION
Adds structured optional fields to the ensemble YAML schema, rendered on both the detail page and index cards.

## New fields

| Field | Type | Description |
|---|---|---|
| `conductors` | list | Name + optional role label (Dirigent, Jugenddirigent …) |
| `address` | object | `name`, `street`, `postcode`, `city`, `maps` (Google Maps link) |
| `founded` | integer | Founding year; shown as "seit YYYY" on cards |
| `active` | boolean | `false` shows a grey "Derzeit inaktiv" badge (used for SBO Schaumburg) |
| `member_count` | integer | Approximate member count |
| `rehearsal` | object | `day`, `time`, `location` |
| `contact` | object | Public `email` and/or `phone` |

## Changes

- **Build pipeline**: JSON-LD enriched with `foundingDate`, `numberOfEmployees`, `member` (conductors as `schema:Person`), structured `PostalAddress` with `hasMap`
- **Templates**: `orchestra.html` renders all new info rows; `index.html` shows founded year and inactive badge on cards
- **CSS**: `.ensemble-inactive-badge` grey pill
- **All 4 existing YAMLs** updated with known data (SBO marked `active: false`)
- **Issue template** `new_entry.md` extended with all new fields
- **Copilot instructions** schema block updated

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>