### PR TITLE
feat: add intro text to homepage (closes #24)

### DIFF
--- a/src/main/css/main.css
+++ b/src/main/css/main.css
@@ -117,6 +117,35 @@ main {
   padding: 2.5rem 0 3rem;
 }
 
+/* ── Site Intro ─────────────────────────────────────────────────── */
+.site-intro {
+  margin-bottom: 2.5rem;
+  padding: 1.75rem 2rem;
+  background: var(--color-surface);
+  border-radius: var(--radius);
+  border-left: 4px solid var(--color-accent);
+  box-shadow: var(--shadow-card);
+}
+
+.site-intro h2 {
+  margin: 0 0 1rem;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+.site-intro p {
+  margin: 0 0 0.9rem;
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--color-text);
+  max-width: 780px;
+}
+
+.site-intro p:last-child {
+  margin-bottom: 0;
+}
+
 /* ── Section heading ────────────────────────────────────────────── */
 .section-heading {
   font-size: 1.5rem;

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -44,6 +44,33 @@
 
   <main>
     <div class="container">
+
+      <section class="site-intro" aria-labelledby="site-intro-heading">
+        <h2 id="site-intro-heading">Musik im Weserbergland</h2>
+        <p>
+          Der Landkreis Schaumburg liegt im Herzen des niedersächsischen Weserberglandes –
+          eingebettet zwischen dem Süntel im Süden, dem Deister im Norden und der Weser im Westen.
+          Die Region ist geprägt von Fachwerkstädten wie Bückeburg und Stadthagen, von dörflicher
+          Ruhe und einem ausgeprägten Gemeinschaftssinn. Musik war darin seit jeher ein fester
+          Bestandteil: Trachtenkapellen begleiteten Schützenfeste und Kirchweihfeiern,
+          Posaunenchöre erklangen zu Erntedank und Advent, und Schulbands gaben jungen Talenten
+          eine erste Bühne.
+        </p>
+        <p>
+          Heute pflegen Sinfonische Blasorchester, Brass Bands, Chöre, Kammerensembles und Big
+          Bands diese lebendige Tradition weiter – mit einem Repertoire, das von klassischer
+          Konzertsinfonie bis hin zu Filmmusik, Jazz und Pop reicht. Ob in historischen Kirchen,
+          auf Freilichtbühnen oder in modernen Konzertsälen: Musik verbindet Menschen im
+          Schaumburger Land.
+        </p>
+        <p>
+          <strong>Musik in Schaumburg</strong> versammelt all diese Ensembles an einem Ort –
+          als Anlaufstelle für Konzertbesucherinnen und -besucher, als Nachschlagewerk für
+          Musikerinnen und Musiker auf der Suche nach einer neuen musikalischen Heimat, und als
+          Hommage an eine Region, in der die Musik nie verstummt ist.
+        </p>
+      </section>
+
       <h2 class="section-heading">Alle Ensembles</h2>
 
       <div class="cards" role="list">


### PR DESCRIPTION
Add a 'Musik im Weserbergland' intro section above the ensemble cards.
The text introduces visitors to the Landkreis Schaumburg, its musical
tradition from Trachtenkapellen and Posaunenchöre to today's orchestras
and brass bands, and explains that diese Seite brings them all together.

Also adds .site-intro CSS: white card with accent left border, readable
line-height, and a max-width to keep the prose comfortable to read.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
