### PR TITLE
refactor: move ensemble card logo to meta row

### DIFF
--- a/src/main/css/main.css
+++ b/src/main/css/main.css
@@ -206,6 +206,13 @@ main {
   flex: 1;
 }
 
+.card-meta-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
 .card-logo {
   width: 64px;
   height: 64px;
@@ -214,7 +221,7 @@ main {
   border: 1px solid var(--color-border);
   background: #fff;
   padding: 4px;
-  margin-bottom: 0.75rem;
+  flex-shrink: 0;
 }
 
 .card-type {
@@ -260,7 +267,7 @@ main {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
-  margin-bottom: 1rem;
+  flex: 1;
 }
 
 .card-meta-item {

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -102,16 +102,6 @@
           {{/image}}
 
           <div class="card-body">
-            {{#logo}}
-            {{#logo.local}}
-            <img class="card-logo"
-                 src="{{{logo.local}}}"
-                 alt="Logo {{title}}"
-                 width="64" height="64"
-                 loading="lazy">
-            {{/logo.local}}
-            {{/logo}}
-
             <span class="card-type">{{typeLabel}}</span>
             {{#isInactive}}<span class="ensemble-inactive-badge">Inaktiv</span>{{/isInactive}}
             <h3 class="card-title" itemprop="name">
@@ -120,7 +110,8 @@
 
             <p class="card-description" itemprop="description">{{description}}</p>
 
-            <div class="card-meta">
+            <div class="card-meta-row">
+              <div class="card-meta">
               {{#location}}
               <span class="card-meta-item">
                 <span aria-hidden="true">📍</span>
@@ -139,6 +130,16 @@
                 <a href="{{{website}}}" itemprop="url" target="_blank" rel="noopener noreferrer">Website</a>
               </span>
               {{/website}}
+              </div>
+              {{#logo}}
+              {{#logo.local}}
+              <img class="card-logo"
+                   src="{{{logo.local}}}"
+                   alt="Logo {{title}}"
+                   width="64" height="64"
+                   loading="lazy">
+              {{/logo.local}}
+              {{/logo}}
             </div>
 
             <a class="card-link" href="ensemble/{{slug}}/index.html">


### PR DESCRIPTION
## Problem

The logo was at the very top of `.card-body`, above the type badge and title. When two adjacent cards differed in having/not having a logo, the type badge and title shifted ~72 px, breaking grid row alignment.

## Solution

The logo now sits **right-aligned beside the meta stack** (location / founding year / website), anchored to the bottom edge via `align-items: flex-end`.

- Cards **with** a logo: meta items on the left, logo flush-right
- Cards **without** a logo: meta items expand to full card width — no gap, no layout shift

Logo remains a 64 × 64 px `object-fit: contain` square — scales down proportionally, no cropping.