### PR TITLE
feat: add membership_fee field to ensemble detail page

### DIFF
--- a/scripts/build-pipeline.mjs
+++ b/scripts/build-pipeline.mjs
@@ -590,6 +590,7 @@ function buildEnsembleView(orch) {
     isInactive: orch.active === false,
     founded: orch.founded || null,
     member_count: orch.member_count || null,
+    membership_fee: orch.membership_fee || null,
     hasGeo,
     geoJson,
   };

--- a/src/main/html/ensemble.html
+++ b/src/main/html/ensemble.html
@@ -174,6 +174,12 @@
         </div>
         {{/contact.hasPhone}}
         {{/hasContact}}
+        {{#membership_fee}}
+        <div class="info-row">
+          <span class="info-label">💰 Mitgliedsbeitrag</span>
+          <span>{{membership_fee}}</span>
+        </div>
+        {{/membership_fee}}
       </div>
 
       {{#hasSocial}}


### PR DESCRIPTION
## Neues YAML-Feld: `membership_fee`

Fügt das optionale Feld `membership_fee` (String) hinzu, das auf der Ensemble-Detailseite angezeigt wird – **nicht** auf der Startseite.

**Anzeige:** »💰 Mitgliedsbeitrag« in der Info-Tabelle unter Telefon/E-Mail.

**YAML-Beispiel:**
```yaml
membership_fee: '60 €/Jahr (Erwachsene), 30 €/Jahr (Jugendliche)'
```

Dieses PR ist Voraussetzung für kommende Ensemble-Einträge, die Mitgliedsbeiträge angeben.