### PR TITLE
feat: add Musikverein Hülsede e.V.

### DIFF
--- a/ensembles/musikverein-huelsede/index.yaml
+++ b/ensembles/musikverein-huelsede/index.yaml
@@ -1,5 +1,5 @@
 title: 'Musikverein Hülsede e.V.'
-type: brass-band
+type: blaskapelle
 slug: musikverein-huelsede
 
 active: true

--- a/scripts/build-pipeline.mjs
+++ b/scripts/build-pipeline.mjs
@@ -49,6 +49,7 @@ const IMAGE_WIDTHS = [400, 800, 1200];
 const LOGO_SIZE = 128;
 
 const TYPE_LABELS = {
+  'blaskapelle': 'Blaskapelle',
   'brass-band': 'Brass Band',
   'symphony': 'Sinfonisches Blasorchester',
   'symphony-orchestra': 'Sinfonieorchester',


### PR DESCRIPTION
## Musikverein Hülsede e.V.

**Typ:** Brass Band / Musikverein
**Ort:** Hülsede

### Recherche-Notizen
- Benutzerdaten: Facebook und Instagram (authentisch laut Aufgabenstellung)
- Keine eigene Website gefunden (musikverein-huelsede.de, mv-huelsede.de – nicht registriert)
- Kein Dirigent, Gründungsjahr, Mitgliederzahl oder Probenzeiten öffentlich verfügbar
- Kein Logo/Foto verfügbar

### ⚠️ Reviewer-Hinweise
- Datenlage sehr dünn – nur Social Media bekannt
- Typ »Brass Band« ist eine Annahme bei »Musikverein«; bitte prüfen und ggf. korrigieren
- Koordinaten (52.2607, 9.3709) sind ein Näherungswert für Hülsede
- **Als möglicher Spam-Eintrag eingestuft**: Nur Social-Media-Präsenz, keine verifizierbaren Aktivitätsnachweise gefunden. Bitte durch Ortskundige prüfen.