### PR TITLE
feat: add Chor Joy to Sing (Kirchengemeinde Steinbergen)

### DIFF
--- a/ensembles/chor-joy-to-sing/index.yaml
+++ b/ensembles/chor-joy-to-sing/index.yaml
@@ -34,7 +34,7 @@ rehearsal:
 
 contact:
   email: 'mail@julia-knubbe.de'
-  phone: '+49 176 84 63 68 00'
+  phone: '+4917684636800'
 
 social:
   instagram: 'https://www.instagram.com/_juliaknubbe_/'


### PR DESCRIPTION
## Chor Joy to Sing

**Website:** https://julia-knubbe.de/chor
**Typ:** Chor (Gemeindechor der Kirche Steinbergen)
**Leitung:** Julia Knubbe
**Probe:** Mittwoch 20:00–21:35 Uhr, Jugendhaus der Kirche Steinbergen, Kirchstraße 11, 31737 Rinteln
**Kommende Auftritte:** Jubiläumskonzert 15.06.2025, St. Agnes Steinbergen

### Recherche-Notizen
- Daten direkt von julia-knubbe.de/chor verifiziert
- Kein Foto/Logo für diesen Chor spezifisch verfügbar (gemeinsames Foto mit HeartChor auf der Website)
- Instagram verweist auf Julia Knubbe als Chorleiterin

### ⚠️ Reviewer-Hinweise
- Koordinaten (52.1951, 9.1303) sind für Steinbergen bei Rinteln (Nominatim)
- »Gemeindechor der Kirche« deutet auf kirchliche Trägerschaft hin; kein separater Vereinsstatus geprüft
- Kein Mitgliedsbeitrag auf der Website genannt