### PR TITLE
feat: add Kinderchor Rodenberg (Julia Knubbe)

### DIFF
--- a/ensembles/kinderchor-rodenberg/index.yaml
+++ b/ensembles/kinderchor-rodenberg/index.yaml
@@ -29,7 +29,7 @@ website: 'https://julia-knubbe.de/chor'
 
 rehearsal:
   day: 'Montag'
-  time: '16:30'
+  time: '16:30–17:15 Uhr'
   location: 'St. Johannes / Gemeindehaus, Rodenberg'
 
 contact:


### PR DESCRIPTION
## Kinderchor Rodenberg

**Website:** https://julia-knubbe.de/chor
**Typ:** Chor (Kinderchor, 6–7 Jahre)
**Leitung:** Julia Knubbe
**Probe:** Montag 16:30–17:15 Uhr, St. Johannes / Gemeindehaus, Lange Straße 82, 31552 Rodenberg
**Probestunden:** 2 kostenlose Probestunden (01.09.25 und 08.09.25)

### Recherche-Notizen
- Daten direkt von julia-knubbe.de/chor verifiziert
- Kein spezifisches Logo/Foto für den Kinderchor vorhanden
- Kein Mitgliedsbeitrag auf der Website genannt

### ⚠️ Reviewer-Hinweise
- Koordinaten (52.2936, 9.3426) für Rodenberg
- Für Kinder von 6 bis 7 Jahren – bei älteren Kindern ist die HeartChor-Option besser geeignet