### PR TITLE
ux: add short preamble on homepage, move intro text below cards

### DIFF
--- a/src/main/css/main.css
+++ b/src/main/css/main.css
@@ -164,8 +164,16 @@ main {
 }
 
 /* ── Site Intro ─────────────────────────────────────────────────── */
+.site-preamble {
+  margin: 0 0 1.75rem;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: var(--color-text);
+  max-width: 820px;
+}
+
 .site-intro {
-  margin-bottom: 2.5rem;
+  margin-top: 3rem;
   padding: 1.75rem 2rem;
   background: var(--color-surface);
   border-radius: var(--radius);

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -57,31 +57,11 @@
   <main>
     <div class="container">
 
-      <section class="site-intro" aria-labelledby="site-intro-heading">
-        <h2 id="site-intro-heading">Musik im Weserbergland</h2>
-        <p>
-          Der Landkreis Schaumburg liegt im Herzen des niedersächsischen Weserberglandes –
-          eingebettet zwischen dem Süntel im Süden, dem Deister im Norden und der Weser im Westen.
-          Die Region ist geprägt von Fachwerkstädten wie Bückeburg und Stadthagen, von dörflicher
-          Ruhe und einem ausgeprägten Gemeinschaftssinn. Musik war darin seit jeher ein fester
-          Bestandteil: Trachtenkapellen begleiteten Schützenfeste und Kirchweihfeiern,
-          Posaunenchöre erklangen zu Erntedank und Advent, und Schulbands gaben jungen Talenten
-          eine erste Bühne.
-        </p>
-        <p>
-          Heute pflegen Sinfonische Blasorchester, Brass Bands, Chöre, Kammerensembles und Big
-          Bands diese lebendige Tradition weiter – mit einem Repertoire, das von klassischer
-          Konzertsinfonie bis hin zu Filmmusik, Jazz und Pop reicht. Ob in historischen Kirchen,
-          auf Freilichtbühnen oder in modernen Konzertsälen: Musik verbindet Menschen im
-          Schaumburger Land.
-        </p>
-        <p>
-          <strong>Musik in Schaumburg</strong> versammelt all diese Ensembles an einem Ort –
-          als Anlaufstelle für Konzertbesucherinnen und -besucher, als Nachschlagewerk für
-          Musikerinnen und Musiker auf der Suche nach einer neuen musikalischen Heimat, und als
-          Hommage an eine Region, in der die Musik nie verstummt ist.
-        </p>
-      </section>
+      <p class="site-preamble">
+        Willkommen bei »Musik in Schaumburg«. Dieses Verzeichnis listet aktive und inaktive
+        Musik-Ensembles aus dem Landkreis Schaumburg (Niedersachsen) auf – von klassischen
+        Orchestern im Weserbergland bis zu modernen Big Bands in Stadthagen und Bückeburg.
+      </p>
 
       <h2 class="section-heading">Alle Ensembles</h2>
 
@@ -167,6 +147,26 @@
       </div>
     </div>
   </main>
+
+  <section class="site-intro" aria-labelledby="site-intro-heading">
+    <div class="container">
+      <h2 id="site-intro-heading">Musik im Weserbergland</h2>
+      <p>
+        Der Landkreis Schaumburg liegt im Herzen des niedersächsischen Weserberglandes –
+        zwischen dem Süntel im Süden, dem Deister im Norden und der Weser im Westen.
+        Fachwerkstädte wie Bückeburg und Stadthagen, dörfliche Gemeinschaft und gelebte
+        Musiktradition prägen die Region: Trachtenkapellen bei Schützenfesten,
+        Posaunenchöre zu Erntedank und Advent, Schulbands für den Nachwuchs.
+      </p>
+      <p>
+        Heute setzen Sinfonische Blasorchester, Brass Bands, Chöre, Kammerensembles und Big
+        Bands diese Tradition fort – mit Repertoire von Konzertsinfonie bis Jazz und Pop,
+        in historischen Kirchen ebenso wie auf Freilichtbühnen.
+        <strong>Musik in Schaumburg</strong> versammelt all diese Ensembles als Anlaufstelle
+        für Konzertbesucher und Musikerinnen auf der Suche nach ihrer musikalischen Heimat.
+      </p>
+    </div>
+  </section>
 
   <footer class="site-footer">
     <div class="container">


### PR DESCRIPTION
Move the three-paragraph 'Musik im Weserbergland' section to the
bottom of the page (after the ensemble cards) to reduce bounce rate.

Add a concise 1-sentence preamble at the top – immediately after
the hero header – so first-time visitors instantly understand what
the site is about without scrolling past dense text.

Also lightly trim the intro text: remove redundant adjectives,
merge two paragraphs for tighter reading.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
