### PR TITLE
fix(htaccess): 301-Redirect /index.html → / für kanonische URL

### DIFF
--- a/src/main/.htaccess
+++ b/src/main/.htaccess
@@ -23,6 +23,12 @@ RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
 RewriteRule ^ https://%1%{REQUEST_URI} [R=301,L]
 
+# ── Canonical redirect: /index.html → / ──────────────────────────────────────
+# Apache's mod_dir may externally redirect / to /index.html; this rule
+# ensures any explicit /index.html request is canonicalised back to /.
+RewriteCond %{THE_REQUEST} \ /index\.html[\ ?] [NC]
+RewriteRule ^index\.html$ / [R=301,L]
+
 # ── Pre-compressed asset serving ──────────────────────────────────────────────
 # Priority: zstd > brotli > gzip.
 # Each rule checks that (a) the client advertises support and


### PR DESCRIPTION
## Problem

Apache's `mod_dir` kann eine externe Umleitung von `/` nach `/index.html` durchführen. Die kanonische URL in `index.html` ist jedoch `https://musik-in-schaumburg.de/` – die URLs stimmen dann nicht überein, was Google als Duplikat-Content werten kann.

## Lösung

Neue RewriteRule in `.htaccess`, die explizite Anfragen an `/index.html` per **301** zurück auf `/` leitet:

```apache
RewriteCond %{THE_REQUEST} \ /index\.html[\ ?] [NC]
RewriteRule ^index\.html$ / [R=301,L]
```

`%{THE_REQUEST}` enthält die ursprüngliche HTTP-Anfrage (z. B. `GET /index.html HTTP/1.1`) und greift deshalb nur bei echten Client-Anfragen an `/index.html` – nicht bei Apaches interner DirectoryIndex-Verarbeitung, wenn `/` direkt aufgerufen wird. Kein Redirect-Loop möglich.